### PR TITLE
Add extension names, and add '-nmm' mask option

### DIFF
--- a/defaults.h
+++ b/defaults.h
@@ -62,6 +62,7 @@
 #define D_FILLNOISE     0       /* value put on masked pixels in noise image */
 #define D_NOILAYER      0       /* add pure noise image as output image layer */
 #define D_SIGLAYER      0       /* add noise-scaled diff image as output image layer */
+#define D_MASKLAYER     0       /* add mask image as output image layer */
 #define D_CONVLAYER     0       /* add convolved image as output image layer */
 #define D_OUTSUM        0       /* output image is *SUM* of input images */
 #define D_NOCLOBBER     0       /* do not clobber output image - nice double negative */

--- a/globals.h
+++ b/globals.h
@@ -46,7 +46,7 @@ char      *forceConvolve, *photNormalize, *figMerit;
 int       rescaleOK;
 float     fillVal, fillValNoise;
 char      *noiseImage, *sigmaImage, *convImage;
-int       inclNoiseImage, inclSigmaImage, inclConvImage, noClobber;
+int       inclNoiseImage, inclSigmaImage, inclConvImage, inclMaskImage, noClobber;
 int       doKerInfo, outShort, outNShort;
 float     outBzero, outBscale, outNiBzero, outNiBscale;
 int       convolveVariance;

--- a/main.c
+++ b/main.c
@@ -1245,6 +1245,20 @@ void processRegion(void *voidData) {
             printError(status);
     }
 
+    if (inclMaskImage) {
+        if (fits_movrel_hdu(oPtr, 1, NULL, &status))
+            printError(status);
+
+        if (hp_fits_write_subset_int(oPtr, 0, 2, oNaxes, mRData, &status,
+                                     1, 32768, 1, fpixelOutX, fpixelOutY,
+                                     lpixelOutX, lpixelOutY, xBufLo, yBufLo, mRData, rPixX, rPixY))
+            printError(status);
+        /* reset output stream */
+        if (fits_write_key_str(oPtr, hKeyword, hInfo, "", &status) ||
+            fits_set_bscale(oPtr, outBscale, outBzero, &status))
+            printError(status);
+    }
+
     /* add fits header info */
     fits_movabs_hdu(oPtr, 1, NULL, &status);
 
@@ -1720,6 +1734,21 @@ int main(int argc, char *argv[]) {
                 printError(status);
         }
     }
+
+    if (inclMaskImage) {
+        if (fits_insert_img(oPtr, SHORT_IMG, 2, oNaxes, &status))
+            printError(status);
+        if (fits_update_key(oPtr, TSTRING, "OBJECT", "Pixel mask image", "", &status) ||
+            fits_update_key(oPtr, TSTRING, "EXTNAME", "MASK_IMAGE", "", &status))
+            printError(status);
+
+        if (fits_update_key_flt(oPtr, "BZERO", 32768, -5, "", &status) ||
+            fits_update_key_flt(oPtr, "BSCALE", 1, -5, "", &status))
+            printError(status);
+
+    }
+
+
     if (noiseImage) {
         if (!noClobber) { sprintf(scrStr, "!%s", noiseImage); }
         else { sprintf(scrStr, "%s", noiseImage); }

--- a/main.c
+++ b/main.c
@@ -1666,7 +1666,8 @@ int main(int argc, char *argv[]) {
     /* make new image extensions for any extraneous output data */
     if (inclConvImage) {
         if (fits_insert_img(oPtr, oBitpix, oNaxis, oNaxes, &status) ||
-            fits_update_key(oPtr, TSTRING, "OBJECT", "Convolved Image", "", &status))
+            fits_update_key(oPtr, TSTRING, "OBJECT", "Convolved Image", "", &status) ||
+            fits_update_key(ePtr, TSTRING, "EXTNAME", "IMAGE_CONV", "", &status))
             printError(status);
     }
     if (convImage) {
@@ -1676,13 +1677,15 @@ int main(int argc, char *argv[]) {
             fits_create_img(ePtr, oBitpix, oNaxis, oNaxes, &status) ||
             hp_fits_copy_header(iPtr, ePtr, &status) ||
             fits_update_key(ePtr, TSTRING, "OBJECT", "Convolved Image", "", &status) ||
+            fits_update_key(ePtr, TSTRING, "EXTNAME", "IMAGE_CONV", "", &status) ||
             fits_close_file(ePtr, &status))
             printError(status);
     }
 
     if (inclSigmaImage) {
         if (fits_insert_img(oPtr, oBitpix, 2, oNaxes, &status) ||
-            fits_update_key(oPtr, TSTRING, "OBJECT", "Noise-scaled (sigma) Difference Image", "", &status))
+            fits_update_key(oPtr, TSTRING, "OBJECT", "Noise-scaled (sigma) Difference Image", "", &status) ||
+            fits_update_key(ePtr, TSTRING, "EXTNAME", "RMS_IMAGE_SCALED", "", &status))
             printError(status);
     }
     if (sigmaImage) {
@@ -1692,6 +1695,7 @@ int main(int argc, char *argv[]) {
             fits_create_img(ePtr, oBitpix, oNaxis, oNaxes, &status) ||
             hp_fits_copy_header(iPtr, ePtr, &status) ||
             fits_update_key(ePtr, TSTRING, "OBJECT", "Noise-scaled (sigma) Difference Image", "", &status) ||
+            fits_update_key(ePtr, TSTRING, "EXTNAME", "RMS_IMAGE_SCALED", "", &status) ||
             fits_close_file(ePtr, &status))
             printError(status);
     }
@@ -1705,6 +1709,8 @@ int main(int argc, char *argv[]) {
                 printError(status);
         }
         if (fits_update_key(oPtr, TSTRING, "OBJECT", "HOTPanTS Noise Image", "", &status))
+            printError(status);
+        if (fits_update_key(oPtr, TSTRING, "EXTNAME", "RMS_IMAGE", "", &status))
             printError(status);
 
         /* manually set bscale and bzero for noise image layer */
@@ -1733,7 +1739,8 @@ int main(int argc, char *argv[]) {
             fits_update_key(ePtr, TSTRING, "OBJECT", "HOTPanTS Noise Image", "", &status) ||
             fits_update_key_flt(ePtr, "GAIN", 1., -1, "No gain in noise image", &status) ||
             fits_update_key_flt(ePtr, "RDNOISE", 0., -1, "No rdnoise in noise image", &status) ||
-            fits_write_key_flt(ePtr, "MASKVAL", fillValNoise, -6, "Value of Masked Pixels", &status))
+            fits_write_key_flt(ePtr, "MASKVAL", fillValNoise, -6, "Value of Masked Pixels", &status) ||
+            fits_write_key_flt(ePtr, "EXTNAME", fillValNoise, -6, "RMS_IMAGE", &status))
             printError(status);
 
         if (outNShort)

--- a/vargs.c
+++ b/vargs.c
@@ -96,6 +96,7 @@ void vargs(int argc, char *argv[]) {
     fillValNoise = D_FILLNOISE;
     inclNoiseImage = D_NOILAYER;
     inclSigmaImage = D_SIGLAYER;
+    inclMaskImage = D_MASKLAYER;
     inclConvImage = D_CONVLAYER;
     noClobber = D_NOCLOBBER;
     doKerInfo = D_KINFO;
@@ -193,6 +194,8 @@ void vargs(int argc, char *argv[]) {
     sprintf(help, "%s   [-nim]            : add noise image as layer to sub image (%d)\n", help, inclNoiseImage);
     sprintf(help, "%s   [-ndm]            : add noise-scaled sub image as layer to sub image (%d)\n\n", help,
             inclSigmaImage);
+    sprintf(help, "%s   [-nmm]            : add mask image as layer to sub image (%d)\n\n", help,
+            inclMaskImage);
     sprintf(help, "%s   [-oci fitsfile]   : output convolved image (undef)\n", help);
     sprintf(help, "%s   [-cim]            : add convolved image as layer to sub image (%d)\n\n", help, inclConvImage);
 
@@ -356,6 +359,8 @@ void vargs(int argc, char *argv[]) {
                 inclNoiseImage = 1;
             } else if (strcasecmp(argv[iarg] + 1, "ndm") == 0) {
                 inclSigmaImage = 1;
+            } else if (strcasecmp(argv[iarg] + 1, "nmm") == 0) {
+                inclMaskImage = 1;
             } else if (strcasecmp(argv[iarg] + 1, "oci") == 0) {
                 convImage = argv[++iarg];
             } else if (strcasecmp(argv[iarg] + 1, "cim") == 0) {

--- a/vargs.c
+++ b/vargs.c
@@ -194,7 +194,7 @@ void vargs(int argc, char *argv[]) {
     sprintf(help, "%s   [-nim]            : add noise image as layer to sub image (%d)\n", help, inclNoiseImage);
     sprintf(help, "%s   [-ndm]            : add noise-scaled sub image as layer to sub image (%d)\n\n", help,
             inclSigmaImage);
-    sprintf(help, "%s   [-nmm]            : add mask image as layer to sub image (%d)\n\n", help,
+    sprintf(help, "%s   [-mim]            : add mask image as layer to sub image (%d)\n\n", help,
             inclMaskImage);
     sprintf(help, "%s   [-oci fitsfile]   : output convolved image (undef)\n", help);
     sprintf(help, "%s   [-cim]            : add convolved image as layer to sub image (%d)\n\n", help, inclConvImage);
@@ -359,7 +359,7 @@ void vargs(int argc, char *argv[]) {
                 inclNoiseImage = 1;
             } else if (strcasecmp(argv[iarg] + 1, "ndm") == 0) {
                 inclSigmaImage = 1;
-            } else if (strcasecmp(argv[iarg] + 1, "nmm") == 0) {
+            } else if (strcasecmp(argv[iarg] + 1, "mim") == 0) {
                 inclMaskImage = 1;
             } else if (strcasecmp(argv[iarg] + 1, "oci") == 0) {
                 convImage = argv[++iarg];


### PR DESCRIPTION
This PR adds two new items:
- The RMS image and mask image extensions in the output difference image now have names: "RMS_IMAGE" and "MASK_IMAGE". This is largely cosmetic.
- Adds the '-nmm' command line flag, which adds a HDU to the main output image containing the mask image. This saves writing an additional FITS file, and avoids use of the '-allm' flag which outputs (potentially) unnecessary info.